### PR TITLE
chore: pin dependencies to immutable SHAs via ghat

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,9 +9,9 @@ jobs:
     name: versioning
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Bump version and push tag
-        uses: anothrNick/github-tag-action@master
+        uses: anothrNick/github-tag-action@4ed44965e0db8dab2b466a16da04aec3cc312fd8 # 1.75.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BUMP: patch

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/terraform
+FROM hashicorp/terraform:latest@sha256:c89ed543266c8756e04791fd68eaa45063c91f802a793c0df6cb522ee435ba2d
 
 RUN apk update && \
     apk add --update \

--- a/examples/aws-codebuild-container/Dockerfile
+++ b/examples/aws-codebuild-container/Dockerfile
@@ -1,3 +1,3 @@
-FROM hashicorp/terraform
+FROM hashicorp/terraform:latest@sha256:c89ed543266c8756e04791fd68eaa45063c91f802a793c0df6cb522ee435ba2d
 COPY install-awscli.sh install-awscli.sh
 CMD ["install-awscli.sh"]

--- a/examples/kms/eu-west-1/module.kms.tf
+++ b/examples/kms/eu-west-1/module.kms.tf
@@ -1,6 +1,5 @@
 module "kms" {
-  source      = "JamesWoolfenden/kms/aws"
-  version     = "0.0.3"
+  source = "git::https://github.com/JamesWoolfenden/terraform-aws-kms.git?ref=37b7448bc1bf47c0e4fa5e7be241583801195eea" #v0.0.3
   common_tags = var.common_tags
   key         = var.key
   accounts    = var.accounts

--- a/examples/kms/eu-west-2/module.kms.tf
+++ b/examples/kms/eu-west-2/module.kms.tf
@@ -1,6 +1,5 @@
 module "kms" {
-  source      = "JamesWoolfenden/kms/aws"
-  version     = "0.0.3"
+  source = "git::https://github.com/JamesWoolfenden/terraform-aws-kms.git?ref=37b7448bc1bf47c0e4fa5e7be241583801195eea" #v0.0.3
   common_tags = var.common_tags
   key         = var.key
   accounts    = var.accounts


### PR DESCRIPTION
Automated dependency pinning by [ghat](https://github.com/JamesWoolfenden/ghat).

Pins GitHub Actions, pre-commit hooks, Terraform modules/providers, Dockerfiles, and Kubernetes images to SHA digests.