### PR TITLE
chore: pin dependencies to immutable SHAs via ghat

### DIFF
--- a/examples/kms/eu-west-1/module.kms.tf
+++ b/examples/kms/eu-west-1/module.kms.tf
@@ -1,5 +1,5 @@
 module "kms" {
-  source = "git::https://github.com/JamesWoolfenden/terraform-aws-kms.git?ref=37b7448bc1bf47c0e4fa5e7be241583801195eea" #v0.0.3
+  source = "git::https://github.com/JamesWoolfenden/terraform-aws-kms.git?ref=5e86ff865ce2139fb4af32686f541c234bd12b98" #v0.0.51
   common_tags = var.common_tags
   key         = var.key
   accounts    = var.accounts

--- a/examples/kms/eu-west-2/module.kms.tf
+++ b/examples/kms/eu-west-2/module.kms.tf
@@ -1,5 +1,5 @@
 module "kms" {
-  source = "git::https://github.com/JamesWoolfenden/terraform-aws-kms.git?ref=37b7448bc1bf47c0e4fa5e7be241583801195eea" #v0.0.3
+  source = "git::https://github.com/JamesWoolfenden/terraform-aws-kms.git?ref=5e86ff865ce2139fb4af32686f541c234bd12b98" #v0.0.51
   common_tags = var.common_tags
   key         = var.key
   accounts    = var.accounts


### PR DESCRIPTION
Automated dependency pinning by [ghat](https://github.com/JamesWoolfenden/ghat).

Pins GitHub Actions, pre-commit hooks, Terraform modules/providers, Dockerfiles, and Kubernetes images to SHA digests.